### PR TITLE
replace deprecated set-output commands

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,4 +28,4 @@ report=$(/dockerfile-benchmarker --directory "$DIRECTORY" --dockerfile-pattern "
 
 echo $report
 
-echo "::set-output name=violation_report::${report}"
+echo "violation_report=${report}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Got the following warning after running in github action. Hoping this will fix the warning.

> Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
